### PR TITLE
Add a clear method to clear all data in the mock bases so that airtablemock does not conflict across several unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * Added unit tests.
 * Fixed the get method that had many syntax errors.
+* Added a `clear()` method to clear all data in the mock bases.

--- a/airtablemock/__init__.py
+++ b/airtablemock/__init__.py
@@ -1,3 +1,5 @@
+"""A mock for the airtable module to ease unittests."""
+
 import collections
 import itertools
 import logging
@@ -11,8 +13,14 @@ import mock
 _BASES = collections.defaultdict(lambda: collections.defaultdict(collections.OrderedDict))
 
 
+def clear():
+    """Drop all tables from all bases."""
+    _BASES.clear()
+
+
 def patch(target):
     """A function or class decorator to patch the target airtable module with this one."""
+    clear()
     return mock.patch(target, new=sys.modules[__name__])
 
 
@@ -72,7 +80,7 @@ class Airtable(object):
     def create(self, table_name, data):
         """Create a new record."""
         table = self._table(table_name)
-        for i in range(30):
+        for unused_i in range(30):
             record_id = _generate_random_id()
             if record_id not in table:
                 break

--- a/test/airtablemock_test.py
+++ b/test/airtablemock_test.py
@@ -90,6 +90,48 @@ class AirtablemockTestCase(unittest.TestCase):
 
         self.assertEqual([4], [record['fields']['number'] for record in records])
 
+    def test_multiple_bases(self):
+        """Test using the same table name in 2 different bases."""
+
+        base1 = airtablemock.Airtable('first-base')
+        base1.create('multiple-tables', {'number': 6})
+
+        base2 = airtablemock.Airtable('second-base')
+        base2.create('multiple-tables', {'number': 7})
+
+        records = base1.iterate('multiple-tables')
+        self.assertEqual([6], [record['fields']['number'] for record in records])
+
+    def test_multiple_clients(self):
+        """Test accessing a table from different clients."""
+
+        base1 = airtablemock.Airtable('first-base')
+        base1.create('multiple-clients-table', {'number': 8})
+
+        other_client_base1 = airtablemock.Airtable('first-base')
+        other_client_base1.create('multiple-clients-table', {'number': 9})
+
+        records = base1.iterate('multiple-clients-table')
+        self.assertEqual([8, 9], [record['fields']['number'] for record in records])
+
+
+class FunctionsTestCase(unittest.TestCase):
+    """Tests for top level module functions."""
+
+    def test_clear(self):
+        """Basic usage of the clear function."""
+
+        base1 = airtablemock.Airtable('first-base')
+        base1.create('multiple-clients-table', {'number': 8})
+
+        airtablemock.clear()
+
+        other_client_base1 = airtablemock.Airtable('first-base')
+        other_client_base1.create('multiple-clients-table', {'number': 9})
+
+        records = base1.iterate('multiple-clients-table')
+        self.assertEqual([9], [record['fields']['number'] for record in records])
+
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/airtablemock/5)
<!-- Reviewable:end -->
